### PR TITLE
Lima Kisten Update

### DIFF
--- a/co79_GerRng_Zug_3_0.VR/initPlayerLocal.sqf
+++ b/co79_GerRng_Zug_3_0.VR/initPlayerLocal.sqf
@@ -306,11 +306,14 @@ if (getMissionConfigValue "limaSupplyPoints" == "true") then {
 		_iconEod = "a3\ui_f\data\igui\cfg\simpletasks\types\mine_ca.paa";
 		_iconCBRN = "z\ace\addons\medical_gui\data\categories\airway_management.paa";
 		_iconWaGru = "a3\ui_f\data\gui\rsc\rscdisplayarsenal\secondaryweapon_ca.paa";
+		_iconWaGruStatic = "a3\ui_f\data\map\vehicleicons\iconcrategrenades_ca.paa";
 		_iconZug = "a3\ui_f\data\gui\rsc\rscdisplayarsenal\cargomagall_ca.paa";
 		_iconErsatz = "a3\ui_f\data\igui\cfg\actions\repair_ca.paa";
 		_iconSan = "a3\ui_f\data\igui\cfg\simpletasks\types\heal_ca.paa";
 		_iconBodybags = "z\ace\addons\medical_gui\ui\grave.paa";
 		_iconSierra = "a3\weapons_f\data\ui\icon_sniper_ca.paa";
+		_iconVerpflegung ="z\ace\addons\field_rations\ui\icon_hud_hungerstatus.paa";
+
 
 		// Lima Supply Point Static & Mobile
 		{
@@ -357,18 +360,60 @@ if (getMissionConfigValue "limaSupplyPoints" == "true") then {
 							
 				_wagru3 = ["wagru3","WaGru Typ 3 - MAAWS",_icon,{[["wagru3",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru3] call ace_interact_menu_fnc_addActionToObject;
-							
-				_wagru4 = ["wagru4","WaGru Typ 4 - Titan AT",_icon,{[["wagru4",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+
+				_wagru4 = ["wagru4","WaGru Typ 4 - MAAWS Sondermunition",_icon,{[["wagru4",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru4] call ace_interact_menu_fnc_addActionToObject;
 							
-				_wagru5 = ["wagru5","WaGru Typ 5 - Titan AA",_icon,{[["wagru5",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				_wagru5 = ["wagru4","WaGru Typ 5 - Titan AT",_icon,{[["wagru5",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru5] call ace_interact_menu_fnc_addActionToObject;
 							
-				_wagru6 = ["wagru6","WaGru Typ 6 - Metis",_icon,{[["wagru6",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				_wagru6 = ["wagru6","WaGru Typ 6 - Titan AA",_icon,{[["wagru6",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru6] call ace_interact_menu_fnc_addActionToObject;
-				
-				_wagru7 = ["wagru7","WaGru Typ 7 - Combat Engineering",_icon,{[["wagru7",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+							
+				_wagru7 = ["wagru7","WaGru Typ 7 - Metis",_icon,{[["wagru7",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru7] call ace_interact_menu_fnc_addActionToObject;
+				
+				_wagru8 = ["wagru8","WaGru Typ 8 - Combat Engineering",_icon,{[["wagru8",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen"], _wagru8] call ace_interact_menu_fnc_addActionToObject;
+
+			
+			_waGruBoxenStatic = ["WaGru Boxen Static","WaGru Boxen Static",_iconWaGruStatic,{ },{true}] call ace_interact_menu_fnc_createAction;
+			[_x, 0, ["ACE_MainActions"], _waGruBoxenStatic] call ace_interact_menu_fnc_addActionToObject;
+				//------------------------------------------------------------------
+				_wagrustat1 = ["WaGruStat1","WaGruStat Typ 1 - M2 Waffe",_icon,{[["WaGruStat1",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat1] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat2 = ["WaGruStat2","WaGruStat Typ 2 - M2 Munition",_icon,{[["WaGruStat2",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat2] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat3 = ["WaGruStat3","WaGruStat Typ 3 - Mk19 Waffe",_icon,{[["WaGruStat3",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat3] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat4 = ["WaGruStat4","WaGruStat Typ 4 - Mk19 Munition",_icon,{[["WaGruStat4",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat4] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat5 = ["WaGruStat5","WaGruStat Typ 5 - TOW Waffe",_icon,{[["WaGruStat5",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat5] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat6 = ["WaGruStat6","WaGruStat Typ 6 - TOW Munition",_icon,{[["WaGruStat6",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat6] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat7 = ["WaGruStat7","WaGruStat Typ 7 - 82mm Mörser Waffe",_icon,{[["WaGruStat7",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat7] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat8 = ["WaGruStat8","WaGruStat Typ 8 - 82mm Munition HE",_icon,{[["WaGruStat8",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat8] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat9 = ["WaGruStat9","WaGruStat Typ 9 - 82mm Sondermunition",_icon,{[["WaGruStat9",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat9] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat10 = ["WaGruStat10","WaGruStat Typ 10 - 60mm Mörser und Standardmunition",_icon,{[["WaGruStat10",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat10] call ace_interact_menu_fnc_addActionToObject;
+
+				_wagrustat11 = ["WaGruStat1","WaGruStat Typ 11 - 60mm Sondermunition",_icon,{[["WaGruStat11",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "WaGru Boxen Static"], _wagrustat11] call ace_interact_menu_fnc_addActionToObject;
+
+
 				//------------------------------------------------------------------
 			// Parent Action für EOD Boxen
 			_eodBoxen = ["EOD Boxen","EOD Boxen",_iconEod,{ },{true}] call ace_interact_menu_fnc_createAction;
@@ -396,7 +441,7 @@ if (getMissionConfigValue "limaSupplyPoints" == "true") then {
 				_cbrn2 = ["CBRN2","Typ 2 - CBRN-Erkundung",_icon,{[["cbrn2",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "CBRN Boxen"], _cbrn2] call ace_interact_menu_fnc_addActionToObject;
 
-				_cbrn3 = ["CBRN2","Typ 3 - CBRN-UGV",_icon,{[["cbrn3",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				_cbrn3 = ["CBRN3","Typ 3 - CBRN-UGV",_icon,{[["cbrn3",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "CBRN Boxen"], _cbrn3] call ace_interact_menu_fnc_addActionToObject;
 				//------------------------------------------------------------------
 			// Parent Action für San Boxen
@@ -406,8 +451,11 @@ if (getMissionConfigValue "limaSupplyPoints" == "true") then {
 				_san1 = ["San1","San Typ 1 - SanMat",_icon,{[["san1",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "San Boxen"], _san1] call ace_interact_menu_fnc_addActionToObject;	
 			
-				_san2 = ["San1","San Typ 2 - Leichensäcke",_iconBodybags,{[["san2",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				_san2 = ["San2","San Typ 2 - Leichensäcke",_iconBodybags,{[["san2",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
 				[_x, 0, ["ACE_MainActions", "San Boxen"], _san2] call ace_interact_menu_fnc_addActionToObject;	
+
+				_san3 = ["San3","San Typ 3 - Verpflegung",_iconVerpflegung,{[["san3",_this#0], limapfad + "limaSupplyPoints.sqf"] remoteExec ["execVM"];},{true}] call ace_interact_menu_fnc_createAction;
+				[_x, 0, ["ACE_MainActions", "San Boxen"], _san3] call ace_interact_menu_fnc_addActionToObject;	
 				//------------------------------------------------------------------
 			// Parent Action für Ersatzteile
 			_ersatzteile = ["Ersatzteile","Ersatzteile",_iconErsatz,{ },{true}] call ace_interact_menu_fnc_createAction;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_1.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_1.sqf
@@ -18,9 +18,9 @@ clearBackpackCargoGlobal _box;
 
 _box addItemCargoGlobal ["U_B_CBRN_Suit_01_Wdl_F", 12];
 _box addItemCargoGlobal ["kat_mask_M04", 12];
-_box addItemCargoGlobal ["ChemicalDetector_01_watch_F", 5];
-_box addItemCargoGlobal ["kat_gasmaskFilter", 36];
-_box addItemCargoGlobal ["kat_sealant", 30];
+_box addItemCargoGlobal ["ChemicalDetector_01_watch_F", 2];
+_box addItemCargoGlobal ["kat_gasmaskFilter", 24];
+_box addItemCargoGlobal ["kat_sealant", 3];
 _box addItemCargoGlobal ["kat_atropine", 12];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_2.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_2.sqf
@@ -16,10 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["U_B_CBRN_Suit_01_Wdl_F", 8];
-_box addBackpackCargoGlobal ["B_CombinationUnitRespirator_01_F",8];
-_box addItemCargoGlobal ["kat_mask_M04", 8];
-_box addItemCargoGlobal ["G_AirPurifyingRespirator_01_F", 8];
+_box addItemCargoGlobal ["U_B_CBRN_Suit_01_Wdl_F", 4];
+_box addBackpackCargoGlobal ["B_CombinationUnitRespirator_01_F",4];
+_box addItemCargoGlobal ["kat_mask_M04", 4];
+_box addItemCargoGlobal ["G_AirPurifyingRespirator_01_F", 4];
 _box addItemCargoGlobal ["ChemicalDetector_01_watch_F", 4];
 _box addItemCargoGlobal ["kat_gasmaskFilter", 16];
 _box addItemCargoGlobal ["kat_sealant", 16];

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_eod_typ_2.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_eod_typ_2.sqf
@@ -1,4 +1,4 @@
-// Kiste EOD Typ II - Ausrüstung
+// Kiste EOD Typ II - Drohnen
 /* Aufruf im Editor mit:
 
 _path = format ["loadouts\%1\lima\box_eod_typ_i.sqf", getMissionConfigValue "fraktion"]; 
@@ -20,8 +20,10 @@ clearBackpackCargoGlobal _box;
 _box addItemCargoGlobal ["ACE_Flashlight_Maglite_ML300L",2];
 _box addBackpackCargoGlobal ["ACE_TacticalLadder_Pack",2];
 _box addItemCargoGlobal ["ACE_UAVBattery",1];
-_box addItemCargoGlobal ["B_UavTerminal",2];
+_box addItemCargoGlobal ["B_UavTerminal",1];
+_box addItemCargoGlobal ["C_UavTerminal",1];
 _box addBackpackCargoGlobal ["B_UGV_02_Demining_backpack_F",1];
+_box addBackpackCargoGlobal ["C_IDAP_UAV_06_antimine_backpack_F",1];
 _box addItemCargoGlobal ["ACE_VMH3",1];
 _box addItemCargoGlobal ["ACE_VMM3",1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_san_typ_3.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_san_typ_3.sqf
@@ -1,0 +1,36 @@
+// Kiste Sanität Typ III - Verpflegung
+// Aufruf im Editor mit     _nul = execvm "scripts\supplies\box_san_typ_3.sqf";
+
+if (! isServer) exitWith {};
+
+_box = _this select 0;
+
+clearWeaponCargoGlobal _box; 
+clearMagazineCargoGlobal _box;
+clearItemCargoGlobal _box;
+clearBackpackCargoGlobal _box;
+
+for "_i" from 0 to random [14,15,20] do 
+{
+    _mre = selectRandom
+    [
+        "ACE_Humanitarian_Ration",
+        "ACE_MRE_BeefStew",
+        "ACE_MRE_ChickenTikkaMasala",
+        "ACE_MRE_ChickenHerbDumplings",
+        "ACE_MRE_CreamChickenSoup",
+        "ACE_MRE_CreamTomatoSoup",
+        "ACE_MRE_LambCurry",
+        "ACE_MRE_MeatballsPasta",
+        "ACE_MRE_SteakVegetables"
+    ];
+    _amount = random [1,4,12];
+    _box addItemCargoGlobal [_mre, _amount];
+};
+
+_box addItemCargoGlobal ["ACE_WaterBottle",16];
+
+
+// für diese Box Gewichtslimit Ignorieren
+//[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;
+//[_box, true, [0, 2, 0], 90, true] call ace_dragging_fnc_setDraggable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_3.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_3.sqf
@@ -17,13 +17,12 @@ clearBackpackCargoGlobal _box;
 
 
 _box addItemCargoGlobal ["launch_MRAWS_green_F", 1];
-_box addItemCargoGlobal ["MAA_MAAWS_ASM509", 2];
-_box addItemCargoGlobal ["MRAWS_HEAT_F", 2];
+_box addItemCargoGlobal ["MRAWS_HEAT_F", 3];
 _box addItemCargoGlobal ["MRAWS_HEAT55_F", 2];
-_box addItemCargoGlobal ["MAA_MAAWS_MT756", 1];
+_box addItemCargoGlobal ["MAA_MAAWS_MT756", 2];
 _box addItemCargoGlobal ["GerRng_MAAWS_GMM_HEAT", 2];
 _box addItemCargoGlobal ["GerRng_MAAWS_GMM_MT", 1];
-_box addItemCargoGlobal ["MAA_MAAWS_HEDP502", 3];
+_box addItemCargoGlobal ["MAA_MAAWS_HEDP502", 4];
 _box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_4.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_4.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ IV - Titan AT
+// Kiste WaGru Typ IV - MAAWS - Sondermunition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_zug_typ_4.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_I_Titan_short_F", 1];
-_box addItemCargoGlobal ["Titan_AT", 4];
-_box addItemCargoGlobal ["Titan_AP", 2];
+_box addItemCargoGlobal ["MAA_MAAWS_ASM509", 4];
+_box addItemCargoGlobal ["MAA_MAAWS_HEDP502", 2];
+_box addItemCargoGlobal ["MAA_MAAWS_SMOKE469", 4];
+_box addItemCargoGlobal ["MAA_MAAWS_ILLUM545", 4];
 _box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_5.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_5.sqf
@@ -1,4 +1,4 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGru Typ IV - Titan AT
 /* Aufruf im Editor mit:
 
 _path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
@@ -16,8 +16,9 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
+_box addItemCargoGlobal ["launch_I_Titan_short_F", 1];
+_box addItemCargoGlobal ["Titan_AT", 4];
+_box addItemCargoGlobal ["Titan_AP", 2];
 _box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_7.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_7.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ VII - Combat Engineering
+// Kiste WaGru Typ VI - Metis AT
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_wagru_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,21 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["CUP_launch_BF3", 2];
-_box addItemCargoGlobal ["ACE_EntrenchingTool", 6];
-_box addItemCargoGlobal ["ACE_Fortify", 4];
-_box addItemCargoGlobal ["DemoCharge_Remote_Mag", 8];
-_box addItemCargoGlobal ["SatchelCharge_Remote_Mag", 2];
-_box addItemCargoGlobal ["ACE_Clacker", 2];
-_box addItemCargoGlobal ["ace_marker_flags_black", 10];
-_box addItemCargoGlobal ["ace_marker_flags_blue", 10];
-_box addItemCargoGlobal ["ace_marker_flags_green", 10];
-_box addItemCargoGlobal ["ace_marker_flags_red", 10];
-_box addItemCargoGlobal ["ACE_SpraypaintBlack", 2];
-_box addItemCargoGlobal ["ACE_SpraypaintBlue", 2];
-_box addItemCargoGlobal ["ACE_SpraypaintGreen", 2];
-_box addItemCargoGlobal ["ACE_SpraypaintRed", 2];
-_box addItemCargoGlobal ["ACE_wirecutter", 6];
+_box addItemCargoGlobal ["launch_O_Vorona_green_F", 1];
+_box addItemCargoGlobal ["Vorona_HEAT", 4];
+_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren
 //[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_8.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagru_typ_8.sqf
@@ -1,0 +1,37 @@
+// Kiste WaGru Typ VII - Combat Engineering
+/* Aufruf im Editor mit:
+
+_path = format ["loadouts\%1\lima\box_wagru_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+null = [this] execVM _path;
+
+*/
+
+if (! isServer) exitWith {};
+
+_box = _this select 0;
+
+clearWeaponCargoGlobal _box; 
+clearMagazineCargoGlobal _box;
+clearItemCargoGlobal _box;
+clearBackpackCargoGlobal _box;
+
+
+_box addItemCargoGlobal ["CUP_launch_BF3", 2];
+_box addItemCargoGlobal ["ACE_EntrenchingTool", 6];
+_box addItemCargoGlobal ["ACE_Fortify", 4];
+_box addItemCargoGlobal ["DemoCharge_Remote_Mag", 8];
+_box addItemCargoGlobal ["SatchelCharge_Remote_Mag", 2];
+_box addItemCargoGlobal ["ACE_Clacker", 2];
+_box addItemCargoGlobal ["ace_marker_flags_black", 10];
+_box addItemCargoGlobal ["ace_marker_flags_blue", 10];
+_box addItemCargoGlobal ["ace_marker_flags_green", 10];
+_box addItemCargoGlobal ["ace_marker_flags_red", 10];
+_box addItemCargoGlobal ["ACE_SpraypaintBlack", 2];
+_box addItemCargoGlobal ["ACE_SpraypaintBlue", 2];
+_box addItemCargoGlobal ["ACE_SpraypaintGreen", 2];
+_box addItemCargoGlobal ["ACE_SpraypaintRed", 2];
+_box addItemCargoGlobal ["ACE_wirecutter", 6];
+
+// für diese Box Gewichtslimit Ignorieren
+//[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;
+//[_box, true, [0, 2, 0], 90, true] call ace_dragging_fnc_setDraggable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_1.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_1.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ I - M2 Waffe
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_1.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,10 +16,8 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
-_box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
+_box addItemCargoGlobal ["GerRng_HMG_M2_Sh_carry", 1];
+_box addItemCargoGlobal ["ace_csw_kordCarryTripod", 1];
 
 // für diese Box Gewichtslimit Ignorieren
 //[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_10.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_10.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ X - 60mm Mörser & Standard Munition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_10.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,8 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_carryWeapon", 1];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_HE", 8];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_smokeWhite", 4];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_flare", 2];
 _box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_11.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_11.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ X - 60mm Sondermunition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_11.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,8 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_HE", 4];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_flare_IR", 6];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_flare", 6];
+_box addItemCargoGlobal ["GerRng_Equipment_GerRng_vz99_smokeWhite", 6];
 _box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_2.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_2.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ II - M2 Munition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_1.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,7 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addItemCargoGlobal ["ace_csw_100Rnd_127x99_mag_red", 6];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_3.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_3.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ III - Mk19 Waffe
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_1.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,10 +16,8 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
-_box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
+_box addItemCargoGlobal ["GerRng_GMG_Mk19", 1];
+_box addItemCargoGlobal ["ace_csw_m3CarryTripodLow", 1];
 
 // für diese Box Gewichtslimit Ignorieren
 //[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_4.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_4.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ IV - Mk19 Munition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_4.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,7 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addItemCargoGlobal ["CUP_compats_48Rnd_40mm_MK19_M", 10];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_5.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_5.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ V - TOW Waffe
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_5.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,10 +16,8 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
-_box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
+_box addItemCargoGlobal ["CUP_TOW2_carry", 1];
+_box addItemCargoGlobal ["ace_csw_m220CarryTripod", 1];
 
 // für diese Box Gewichtslimit Ignorieren
 //[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_6.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_6.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ VI - TOW Munition
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_5.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,7 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addItemCargoGlobal ["CUP_compats_TOW2_M", 4];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_7.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_7.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ VII - 82mm Mörser Waffe
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_7.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,10 +16,10 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
-_box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
+_box addItemCargoGlobal ["CUP_m252_carry", 1];
+_box addItemCargoGlobal ["ace_csw_carryMortarBaseplate", 1];
+_box addItemCargoGlobal ["ACE_PlottingBoard", 1];
+_box addItemCargoGlobal ["ACE_artilleryTable", 1];
 
 // für diese Box Gewichtslimit Ignorieren
 //[_box, true, [0, 1, 1], 0, true] call ace_dragging_fnc_setCarryable;

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_8.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_8.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ VIII - 82mm Mörser Munition HE
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_8.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,7 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addItemCargoGlobal ["ACE_1Rnd_82mm_Mo_HE",16];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_9.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_wagrustat_typ_9.sqf
@@ -1,7 +1,7 @@
-// Kiste WaGru Typ V - Titan AA
+// Kiste WaGruStat Typ IX -  82mm Mörser Sondermunition 
 /* Aufruf im Editor mit:
 
-_path = format ["loadouts\%1\lima\box_zug_typ_vii.sqf", getMissionConfigValue "fraktion"]; 
+_path = format ["loadouts\%1\lima\box_wagrustat_typ_9.sqf", getMissionConfigValue "fraktion"]; 
 null = [this] execVM _path;
 
 */
@@ -16,9 +16,9 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 
-_box addItemCargoGlobal ["launch_B_Titan_olive_F", 1];
-_box addItemCargoGlobal ["Titan_AA", 4];
-_box addBackpackCargoGlobal ["B_AssaultPack_rgr", 1];
+_box addItemCargoGlobal ["ACE_1Rnd_82mm_Mo_Illum", 4];
+_box addItemCargoGlobal ["ACE_1Rnd_82mm_Mo_Smoke", 6];
+_box addItemCargoGlobal ["ACE_1Rnd_82mm_Mo_HE_LaserGuided",2];
 _box addBackpackCargoGlobal ["B_Carryall_green_F", 1];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_zug_typ_4.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_zug_typ_4.sqf
@@ -18,6 +18,7 @@ clearBackpackCargoGlobal _box;
 _box addMagazineCargoGlobal ["SmokeShell",30];
 _box addMagazineCargoGlobal ["SmokeShellGreen",10];
 _box addMagazineCargoGlobal ["SmokeShellRed",10];
+_box addMagazineCargoGlobal ["SmokeShellPurple",10];
 _box addMagazineCargoGlobal ["CUP_HandGrenade_M67",30];
 
 // für diese Box Gewichtslimit Ignorieren

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/limaSupplyPoints.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/limaSupplyPoints.sqf
@@ -39,7 +39,7 @@ switch (toLower _supply) do {
 	};
 
 	case "zug4": {
-		_box = "Box_NATO_Equip_F" createVehicle _boxPos;
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
 		[_box] execvm limapfad + "box_zug_typ_4.sqf";
 	};
@@ -94,8 +94,8 @@ switch (toLower _supply) do {
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
 		[_box] execvm limapfad + "box_wagru_typ_3.sqf";
 	};	
-	
-	case "wagru4": {
+
+		case "wagru4": {
 		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
 		[_box] execvm limapfad + "box_wagru_typ_4.sqf";
@@ -104,7 +104,7 @@ switch (toLower _supply) do {
 	case "wagru5": {
 		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
-		[_box] execvm limapfad + "box_wagru_typ_5.sqf";
+		[_box] execvm limapfad + "box_wagru_typ_6.sqf";
 	};	
 	
 	case "wagru6": {
@@ -114,9 +114,81 @@ switch (toLower _supply) do {
 	};	
 	
 	case "wagru7": {
-		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
 		[_box] execvm limapfad + "box_wagru_typ_7.sqf";
+	};	
+	
+	case "wagru8": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagru_typ_8.sqf";
+	};
+
+		case "wagrustat1": {
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_1.sqf";
+	};
+
+			case "wagrustat2": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_2.sqf";
+	};
+
+			case "wagrustat3": {
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_3.sqf";
+	};
+
+			case "wagrustat4": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_4.sqf";
+	};
+
+			case "wagrustat5": {
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_5.sqf";
+	};
+
+			case "wagrustat6": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_6.sqf";
+	};
+
+			case "wagrustat7": {
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_7.sqf";
+	};
+
+			case "wagrustat8": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_8.sqf";
+	};
+
+			case "wagrustat9": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_9.sqf";
+	};
+
+			case "wagrustat10": {
+		_box = "Box_NATO_WpsLaunch_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_10.sqf";
+	};
+
+			case "wagrustat11": {
+		_box = "ACE_Box_82mm_Mo_HE" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_wagrustat_typ_11.sqf";
 	};
 		
 	case "sierra1": {
@@ -159,6 +231,12 @@ switch (toLower _supply) do {
 		_box = "Land_PlasticCase_01_medium_black_F" createVehicle _boxPos;
 		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
 		[_box] execvm limapfad + "box_san_typ_2.sqf";
+	};	
+
+		case "san3": {
+		_box = "Land_PlasticCase_01_medium_gray_F" createVehicle _boxPos;
+		_box setPosATL [_boxPos select 0,_boxPos select 1,_boxHeight];
+		[_box] execvm limapfad + "box_san_typ_3.sqf";
 	};	
 	
 	case "supply": {

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/GrpFhr_WaGru.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/GrpFhr_WaGru.sqf
@@ -61,6 +61,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -215,6 +216,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Lima.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Lima.sqf
@@ -117,6 +117,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -366,6 +367,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/MasterPackliste.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/MasterPackliste.sqf
@@ -209,6 +209,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -524,6 +525,11 @@
     "CUP_FlareGreen_265_M",
     "CUP_FlareRed_265_M",
     "CUP_StarClusterRed_265_M",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Sanitaeter_WaGru.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Sanitaeter_WaGru.sqf
@@ -47,6 +47,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -143,6 +144,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Spezialpionier.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Spezialpionier.sqf
@@ -70,6 +70,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -229,6 +230,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Waffen_Assi.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Waffen_Assi.sqf
@@ -59,6 +59,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -165,6 +166,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Waffen_Spez.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/packliste/Waffen_Spez.sqf
@@ -66,6 +66,7 @@
     "CUP_MK19_carry",
     "CUP_m252_carry",
     "ace_csw_carryMortarBaseplate",
+    "GerRng_Equipment_GerRng_vz99_carryWeapon",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // uniforms
@@ -179,6 +180,11 @@
     "ACE_1Rnd_82mm_Mo_Illum",
     "ACE_1Rnd_82mm_Mo_Smoke",
     "ACE_1Rnd_82mm_Mo_HE_LaserGuided",
+    "GerRng_Equipment_GerRng_vz99_flare_IR",
+    "GerRng_Equipment_GerRng_vz99_flare",
+    "GerRng_Equipment_GerRng_vz99_HE",
+    "GerRng_Equipment_GerRng_vz99_smokeWhite",
+    "GerRng_Equipment_GerRng_vz99_smokeWhiteVT",
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
     // Grenades / throw


### PR DESCRIPTION
EOD Typ 2:
- added 1 civilian UAV terminal
- changed amount of NATO UAV terminals from 2 to 1
- added 1 civilian Al-6 demining drone

CBRN Typ 1:
- reduced number of Chemical Detectors from 5 to 2
- reduced number of Gas Mask Filters from 36 to 24
- reduced number of Sealant Tubes from 30 to 3

CBRN Typ 2:
- reduced number of CBRN Suits from 8 to 4
- reduced number of Combination Respirator Units from 8 to 4
- reduced number of M04 Masks from 8 to 4
- reduced number of APRs from 8 to 4

Added San Typ 3 - Verpflegung mit:
- 20 random MREs
- 16 Waterbottles

Zug Typ 4:
- added 10 Purple Smoke Grenades

Split up WaGru Typ 3 into 2 seperate Boxes
   - added WaGru Typ 4 MAAWS Sondermunition
   - adjusted naming of WaGru Boxen 3-8 to accomodate

Added New Category to LSP "WaGru Static" mit:
   - Typ 1 M2 Waffe
   - Typ 2 M2 Munition
   - Typ 3 Mk19 Waffe
   - Typ 4 Mk19 Munition
   - Typ 5 TOW Waffe
   - Typ 6 TOW Munition
   - Typ 7 82mm Mörser Waffe
   - Typ 8 82mm Mörser Munition HE
   - Typ 9 82mm Sondermunition
   - Typ 10 60mm Mörser und Standardmunition
   - Typ 11 60mm Sondermunition

Added 60mm Mörser & relevant Munition to Packliste of:
- GrpFhr_WaGru
- Sanitaeter_WaGru
- Spezialpionier
- Waffen_Assi
- Waffen_Spez
- Lima
- Masterpackliste