### PR TITLE
CHANGE - Lima Kisten - Chemical Detector (Contact) mit JCAD Chemical Detector (KAT) austauschen

### DIFF
--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_1.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_1.sqf
@@ -18,7 +18,7 @@ clearBackpackCargoGlobal _box;
 
 _box addItemCargoGlobal ["U_B_CBRN_Suit_01_Wdl_F", 12];
 _box addItemCargoGlobal ["kat_mask_M04", 12];
-_box addItemCargoGlobal ["ChemicalDetector_01_watch_F", 2];
+_box addItemCargoGlobal ["KAT_ChemicalDetector", 2];
 _box addItemCargoGlobal ["kat_gasmaskFilter", 24];
 _box addItemCargoGlobal ["kat_sealant", 3];
 _box addItemCargoGlobal ["kat_atropine", 12];

--- a/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_2.sqf
+++ b/co79_GerRng_Zug_3_0.VR/loadouts/bw2024/lima/box_cbrn_typ_2.sqf
@@ -20,7 +20,7 @@ _box addItemCargoGlobal ["U_B_CBRN_Suit_01_Wdl_F", 4];
 _box addBackpackCargoGlobal ["B_CombinationUnitRespirator_01_F",4];
 _box addItemCargoGlobal ["kat_mask_M04", 4];
 _box addItemCargoGlobal ["G_AirPurifyingRespirator_01_F", 4];
-_box addItemCargoGlobal ["ChemicalDetector_01_watch_F", 4];
+_box addItemCargoGlobal ["KAT_ChemicalDetector", 4];
 _box addItemCargoGlobal ["kat_gasmaskFilter", 16];
 _box addItemCargoGlobal ["kat_sealant", 16];
 _box addItemCargoGlobal ["kat_atropine", 12];


### PR DESCRIPTION
Tauscht die Contact Chem-Detektoren gegen die von Kat aus