### PR TITLE
Update Medical.cfg to ACE 3.20.2

### DIFF
--- a/cba_configs/Medical.cfg
+++ b/cba_configs/Medical.cfg
@@ -2,6 +2,7 @@
 force force ace_medical_ai_enabledFor = 2;
 force force ace_medical_ai_requireItems = 0;
 force force ace_medical_AIDamageThreshold = 1;
+force force ace_medical_alternateArmorPenetration = true;
 force force ace_medical_bleedingCoefficient = 0.3;
 force force ace_medical_blood_bloodLifetime = 1815;
 force force ace_medical_blood_enabledFor = 2;
@@ -9,7 +10,6 @@ force force ace_medical_blood_maxBloodObjects = 500;
 force force ace_medical_deathChance = 1;
 force force ace_medical_dropWeaponUnconsciousChance = 0;
 force force ace_medical_enableVehicleCrashes = true;
-force force ace_medical_engine_damagePassThroughEffect = 1;
 force force ace_medical_fatalDamageSource = 0;
 force force ace_medical_fractureChance = 0.8;
 force force ace_medical_fractures = 1;
@@ -29,6 +29,7 @@ force force ace_medical_statemachine_fatalInjuriesAI = 0;
 force force ace_medical_statemachine_fatalInjuriesPlayer = 2;
 force force ace_medical_useLimbDamage = 0;
 force force ace_medical_vitals_simulateSpO2 = false;
+ace_medical_windowOnWakeUp = 1;
 
 // ACE Medical Interface
 force force ace_medical_feedback_bloodVolumeEffectType = 0;


### PR DESCRIPTION
Title

ADD
windowOnWakeUp
- Arma Window blinkt in Taskleiste, wenn man aufwacht (Clientside)

CHANGE
engine_damagePassThroughEffect >> alternateArmorPenetration
- Variable wurde umgeschrieben
- Setting ist für Armor-Piercing-Ammo, die Armor pierced